### PR TITLE
Debug Print 64bit Aligned Crosslink BAR Numbers

### DIFF
--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -1120,7 +1120,7 @@ static int crosslink_enum_partition(struct switchtec_ntb *sndev,
 
 		dev_dbg(&sndev->stdev->dev,
 			"Crosslink BAR%d addr: %llx\n",
-			i, bar_addr);
+			i*2, bar_addr);
 
 		if (bar_addr != bar_space * i)
 			continue;


### PR DESCRIPTION
Minor issue

Crosslink BARs use 64bit addesses. Fixed the debug logging to reflect the 64bit even BAR numbers to make debugging clearer.

Original dmesg:
> [64562.048063] ntb_hw_switchtec:crosslink_enum_partition: switchtec switchtec0: Crosslink BAR0 addr: 0
> [64562.048097] ntb_hw_switchtec:crosslink_enum_partition: switchtec switchtec0: Crosslink BAR1 addr: 1000000000
> [64562.048131] ntb_hw_switchtec:crosslink_enum_partition: switchtec switchtec0: Crosslink BAR2 addr: 0

After fix:
> [63831.407219] ntb_hw_switchtec:crosslink_enum_partition: switchtec switchtec0: Crosslink BAR0 addr: 0
> [63831.407253] ntb_hw_switchtec:crosslink_enum_partition: switchtec switchtec0: Crosslink BAR2 addr: 1000000000
> [63831.407287] ntb_hw_switchtec:crosslink_enum_partition: switchtec switchtec0: Crosslink BAR4 addr: 0