### PR TITLE
Fixes #13: dma_set_coherent_mask to 64 bits

### DIFF
--- a/switchtec.c
+++ b/switchtec.c
@@ -1309,6 +1309,10 @@ static int switchtec_init_pci(struct switchtec_dev *stdev,
 	if (rc)
 		return rc;
 
+	rc = dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(64));
+	if (rc)
+		return rc;
+
 	pci_set_master(pdev);
 
 	stdev->mmio = pcim_iomap_table(pdev)[0];


### PR DESCRIPTION
to be able to allocate large memory using CMA