### PR TITLE
BugFix - event-wait

### DIFF
--- a/switchtec.c
+++ b/switchtec.c
@@ -821,6 +821,7 @@ static int ioctl_event_ctl(struct switchtec_dev *stdev,
 {
 	int ret;
 	int nr_idxs;
+	unsigned int event_flags;
 	struct switchtec_ioctl_event_ctl ctl;
 
 	if (copy_from_user(&ctl, uctl, sizeof(ctl)))
@@ -842,7 +843,9 @@ static int ioctl_event_ctl(struct switchtec_dev *stdev,
 		else
 			return -EINVAL;
 
+		event_flags = ctl.flags;
 		for (ctl.index = 0; ctl.index < nr_idxs; ctl.index++) {
+			ctl.flags = event_flags;
 			ret = event_ctl(stdev, &ctl);
 			if (ret < 0)
 				return ret;


### PR DESCRIPTION
Bug Description:
For switchtec-user command event-wait, if we do not use option --partition
and --port. The command waits the event of each port. The command firstly
cleans the event of each port, then waits the event.
The bug is it just cleans the event of first port.

Root Cause:
All ports use same data 'struct switchtec_ioctl_event_ctl ctl' and the data
is changed in function event_ctl(). 