### PR TITLE
NTB link cannot up

### DIFF
--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -524,11 +524,16 @@ static int switchtec_ntb_reinit_peer(struct switchtec_ntb *sndev);
 
 static void link_reinit_work(struct work_struct *work)
 {
+	int link_sta;
 	struct switchtec_ntb *sndev;
 
 	sndev = container_of(work, struct switchtec_ntb, link_reinit_work);
 
+	link_sta = sndev->self_shared->link_sta;
+
 	switchtec_ntb_reinit_peer(sndev);
+
+	sndev->self_shared->link_sta = link_sta;
 }
 
 static void switchtec_ntb_check_link(struct switchtec_ntb *sndev,


### PR DESCRIPTION
The link_sta is initialized by switchtec_ntb_link_enable() when loading
ntb_transport module. Because the peer does not load driver, the ntb link
will not be up. When the peer loads the ntb_hw_switchtec module, the
switchtec_ntb_reinit_peer() and switchtec_ntb_init_shared_mw() will be
called. The link_sta will not be re-initialized. the ntb link cannot be up.

This issue can be reproduced by following test.
Test Setup:
           Host 1 <- -> Switchtec <- -> Host 2

Test Steps:
1. Load drivers on host 1
        modprob   ntb
        insmod switchtec.ko
        insmod ntb_hw_switchtec,ko
        modprob  ntb_transport 
        modprob  ntb_netdev
2. Load drivers on host 2.
3. Check the NTB link 

Thanks
joey 