### PR TITLE
add memory barrier between set dma target address and enable dma

### DIFF
--- a/switchtec.c
+++ b/switchtec.c
@@ -1058,6 +1058,7 @@ static void enable_link_state_events(struct switchtec_dev *stdev)
 static void enable_dma_mrpc(struct switchtec_dev *stdev)
 {
 	writeq(stdev->dma_mrpc_dma_addr, &stdev->mmio_mrpc->dma_addr);
+	flush_wc_buf(stdev);
 	iowrite32(SWITCHTEC_DMA_MRPC_EN, &stdev->mmio_mrpc->dma_en);
 }
 
@@ -1067,6 +1068,7 @@ static void stdev_release(struct device *dev)
 
 	if (stdev->dma_mrpc){
 		iowrite32(0, &stdev->mmio_mrpc->dma_en);
+		flush_wc_buf(stdev);
 		writeq(0, &stdev->mmio_mrpc->dma_addr);
 		dma_free_coherent(&stdev->pdev->dev, sizeof(*stdev->dma_mrpc),
 				stdev->dma_mrpc, stdev->dma_mrpc_dma_addr);


### PR DESCRIPTION
in mrpc dma mode, dma target address register with offset
0x810-0x817 and mrpc dma mode enable register with offset 0x80c in
gas space
driver set the dma target address register first, then
enable mrpc dma mode following, but because mrpc section with WC
attribute, these 2 writes were combined and resulting enable dma
first then followed by the dma target address, that's 3 dwords write
from 0x80c to 0x817, add the necessory barrier between

the memory barrier also added when disable mrpc dma