### PR TITLE
Enhance force down link feature.

### DIFF
--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -524,16 +524,10 @@ static int switchtec_ntb_reinit_peer(struct switchtec_ntb *sndev);
 
 static void link_reinit_work(struct work_struct *work)
 {
-	int link_sta;
 	struct switchtec_ntb *sndev;
 
 	sndev = container_of(work, struct switchtec_ntb, link_reinit_work);
-
-	link_sta = sndev->self_shared->link_sta;
-
 	switchtec_ntb_reinit_peer(sndev);
-
-	sndev->self_shared->link_sta = link_sta;
 }
 
 static void switchtec_ntb_check_link(struct switchtec_ntb *sndev,
@@ -1483,10 +1477,13 @@ static void switchtec_ntb_deinit_db_msg_irq(struct switchtec_ntb *sndev)
 
 static int switchtec_ntb_reinit_peer(struct switchtec_ntb *sndev)
 {
-	dev_info(&sndev->stdev->dev, "peer reinitialized\n");
-	switchtec_ntb_deinit_shared_mw(sndev);
-	switchtec_ntb_init_mw(sndev);
-	return switchtec_ntb_init_shared_mw(sndev);
+	int rc;
+
+	dev_info(&sndev->stdev->dev, "reinitialize shared memory window\n");
+	rc = config_rsvd_lut_win(sndev, sndev->mmio_peer_ctrl, 0,
+				 sndev->self_partition,
+				 sndev->self_shared_dma);
+	return rc;
 }
 
 static int switchtec_ntb_add(struct device *dev,


### PR DESCRIPTION
When a host is not a surviving host, but it receives the link force down massage,  it should skip the link force down massage. To reinitialize  the shared memory window, the driver just need to reinitialize the reserved LUT window. 

