### PR TITLE
fix compile error for readq and writeq on unsupport systems

### DIFF
--- a/switchtec.c
+++ b/switchtec.c
@@ -22,7 +22,7 @@
 #include <linux/uaccess.h>
 #include <linux/poll.h>
 #include <linux/wait.h>
-
+#include <linux/io-64-nonatomic-lo-hi.h>
 #include <linux/nospec.h>
 
 #include "version.h"


### PR DESCRIPTION
include <linux/io-64-nonatomic-lo-hi.h> so that readq/writeq is
replaced by two readl/writel on systems that do not support it