### PR TITLE
switchtec: read already defined odb register for flush WC buffer

### DIFF
--- a/switchtec.c
+++ b/switchtec.c
@@ -134,7 +134,7 @@ static void flush_wc_buf(struct switchtec_dev *stdev)
 
 	mmio_dbmsg = (void __iomem *)stdev->mmio_ntb +
 		SWITCHTEC_NTB_REG_DBMSG_OFFSET;
-	ioread32(&mmio_dbmsg->reserved1[0]);
+	ioread32(&mmio_dbmsg->odb);
 }
 
 static void mrpc_cmd_submit(struct switchtec_dev *stdev)


### PR DESCRIPTION
For forward compatible, read already defined but no side effects odb
register instead of reserved register for flush WC buffer

Suggested-by: Logan Gunthorpe <logang@deltatee.com>
Signed-off-by: Wesley Sheng <wesley.sheng@microchip.com>