### PR TITLE
ntb_hw_switchtec: Fix compile warnings on 32bit arch

### DIFF
--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -287,9 +287,9 @@ static void switchtec_ntb_mw_set_direct(struct switchtec_ntb *sndev, int idx,
 	ctl_val |= NTB_CTRL_BAR_DIR_WIN_EN;
 
 	iowrite32(ctl_val, &ctl->bar_entry[bar].ctl);
-	iowrite32(xlate_pos | (size & 0xFFFFF000),
+	iowrite32(xlate_pos | (lower_32_bits(size) & 0xFFFFF000),
 		  &ctl->bar_entry[bar].win_size);
-	iowrite32(size >> 32, &ctl->bar_ext_entry[bar].win_size);
+	iowrite32(upper_32_bits(size), &ctl->bar_ext_entry[bar].win_size);
 	iowrite64(sndev->self_partition | addr,
 		  &ctl->bar_entry[bar].xlate_addr);
 }
@@ -1055,9 +1055,9 @@ static int crosslink_setup_mws(struct switchtec_ntb *sndev, int ntb_lut_idx,
 		ctl_val |= NTB_CTRL_BAR_DIR_WIN_EN;
 
 		iowrite32(ctl_val, &ctl->bar_entry[bar].ctl);
-		iowrite32(xlate_pos | (size & 0xFFFFF000),
+		iowrite32(xlate_pos | (lower_32_bits(size) & 0xFFFFF000),
 			  &ctl->bar_entry[bar].win_size);
-		iowrite32(size >> 32, &ctl->bar_ext_entry[bar].win_size);
+		iowrite32(upper_32_bits(size), &ctl->bar_ext_entry[bar].win_size);
 		iowrite64(sndev->peer_partition | addr,
 			  &ctl->bar_entry[bar].xlate_addr);
 	}


### PR DESCRIPTION
On 32-bit arch, shift a size_t by 32 bits to the right
generating compiler warning: right shift count >= width
of type.
The code is correct, but using the upper_32_bits() and
lower_32_bits() marcos that were introduced for this
operation makes it easier to read and avoids the warning.

Fixes: 6c08394bf06e(ntb_hw_switchtec: Added NT BAR Setup Extension Registers for large MWs)
Signed-off-by: Wesley Sheng <wesley.sheng@microchip.com>