### PR TITLE
switchtec: Fix unintended mask of MRPC event

### DIFF
--- a/switchtec.c
+++ b/switchtec.c
@@ -1184,7 +1184,8 @@ static int mask_event(struct switchtec_dev *stdev, int eid, int idx)
 	if (!(hdr & SWITCHTEC_EVENT_OCCURRED && hdr & SWITCHTEC_EVENT_EN_IRQ))
 		return 0;
 
-	if (eid == SWITCHTEC_IOCTL_EVENT_LINK_STATE)
+	if (eid == SWITCHTEC_IOCTL_EVENT_LINK_STATE ||
+	    eid == SWITCHTEC_IOCTL_EVENT_MRPC_COMP)
 		return 0;
 
 	dev_dbg(&stdev->dev, "%s: %d %d %x\n", __func__, eid, idx, hdr);


### PR DESCRIPTION
In case of two or more events happened simultaneously, MRPC event
maybe masked which lead to no more interrupt for this event,
before the next module remove and install.
In this situation, polling in 500ms time interval instead of
interrupt is leveraged, therefore the MRPC execution respond speed
is lower down evidently.

Fix this issue by skip the mask operation same as LINK event.

Reported-by: Susan He <susan.he@microchip.com>
Signed-off-by: Wesley Sheng <wesley.sheng@microchip.com>