### PR TITLE
ntb_hw_switchtec: remove unnecessary shared MW reinit in crosslink case

### DIFF
--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -1492,6 +1492,9 @@ static int switchtec_ntb_reinit_peer(struct switchtec_ntb *sndev)
 {
 	int rc;
 
+	if (crosslink_is_enabled(sndev))
+		return 0;
+
 	dev_info(&sndev->stdev->dev, "reinitialize shared memory window\n");
 	rc = config_rsvd_lut_win(sndev, sndev->mmio_peer_ctrl, 0,
 				 sndev->self_partition,


### PR DESCRIPTION
The reinit of shared MW when receive FORCE_LINK_DOWN message is
required for non-crosslink case, because the LUT settings for shared
MW of peer is reset after reboot.
But in crosslink case, the LUT setttings in the virtual partition
will not be impact by the peer's reboot, therefore it is unnecessary
to reinit it.

Signed-off-by: Wesley Sheng <wesley.sheng@microchip.com>