### PR TITLE
switchtec: Remove unnecessary ternary operator

### DIFF
--- a/switchtec.c
+++ b/switchtec.c
@@ -1392,7 +1392,7 @@ static int switchtec_init_pci(struct switchtec_dev *stdev,
 	if (!use_dma_mrpc)
 		return 0;
 
-	if(!(ioread32(&stdev->mmio_mrpc->dma_ver)? true : false))
+	if (!ioread32(&stdev->mmio_mrpc->dma_ver))
 		return 0;
 
 	stdev->dma_mrpc = dma_zalloc_coherent(&stdev->pdev->dev, sizeof(*stdev->dma_mrpc),


### PR DESCRIPTION
Remove ternary operator which doesn't make sense

This commit was response of feedback from Bjorn Helgaas
in the procedure of upstream.
https://lore.kernel.org/patchwork/patch/1023094/

Signed-off-by: Wesley Sheng <wesley.sheng@microchip.com>