### PR TITLE
Update README.rst to include BAR prefetchable requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,13 @@ The following IOCTLs are also supported by the device:
   and Switchtec Logic Port ID and Partition number (which is more
   user friendly).
 
+Management & NT Endpoint configuration
+======================================
+
+For improving MRPC efficiency by leveraging write combining, it requires
+the following configuration setting:
+
+* BAR Prefetchable
 
 Non-Transparent Bridge (NTB) Driver
 ===================================


### PR DESCRIPTION
For improving MRPC efficiency by leveraging write combining, it
requires the BAR prefetchable bit set for Management/NT Endpoint.

Story about this patch:
In case of BAR prefetchable bit cleared, there will be only
resource0 under /sys/devices/ of sysfs for the Management/NT EP,
different to the bit set case, both resource0 and resource0_wc.
It lead to user space tool could not work when it need to memory
map resource0_wc.

While on the other hand, write combining feature only enabled when
BAR prefetchable bit is set actually.

Signed-off-by: Wesley Sheng <wesley.sheng@microchip.com>