### PR TITLE
switchtec: Choose a better DMA addressing limitation query API

### DIFF
--- a/switchtec.c
+++ b/switchtec.c
@@ -1348,7 +1348,7 @@ static int switchtec_init_pci(struct switchtec_dev *stdev,
 	if (rc)
 		return rc;
 
-	rc = dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(64));
+	rc = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
 	if (rc)
 		return rc;
 


### PR DESCRIPTION
dma_set_coherent_mask() API query for consistent allocations.
However, that's rare case that a device driver only uses
consistent allocations. Choose the better one:
dma_set_mask_and_coherent() API, which will query the mask for
both streaming and coherent together.

Signed-off-by: Wesley Sheng <wesley.sheng@microchip.com>