### PR TITLE
Add permission check for the GAS access MRPC commands

### DIFF
--- a/linux/switchtec.h
+++ b/linux/switchtec.h
@@ -34,6 +34,11 @@
 #define SWITCHTEC_EVENT_FATAL    BIT(4)
 
 #define SWITCHTEC_DMA_MRPC_EN	BIT(0)
+
+#define MRPC_GAS_READ 0x29
+#define MRPC_GAS_WRITE 0x87
+#define MRPC_CMD_ID(x) ((x) & 0xffff)
+
 enum {
 	SWITCHTEC_GAS_MRPC_OFFSET       = 0x0000,
 	SWITCHTEC_GAS_TOP_CFG_OFFSET    = 0x1000,

--- a/switchtec.c
+++ b/switchtec.c
@@ -452,6 +452,12 @@ static ssize_t switchtec_dev_write(struct file *filp, const char __user *data,
 		rc = -EFAULT;
 		goto out;
 	}
+	if (((MRPC_CMD_ID(stuser->cmd) == MRPC_GAS_WRITE) ||
+	     (MRPC_CMD_ID(stuser->cmd) == MRPC_GAS_READ)) &&
+	    !capable(CAP_SYS_ADMIN)) {
+		rc = -EPERM;
+		goto out;
+	}
 
 	data += sizeof(stuser->cmd);
 	rc = copy_from_user(&stuser->data, data, size - sizeof(stuser->cmd));


### PR DESCRIPTION
For the local and remote GAS access MRPC commands, the process need
to be either privileged which make it bypass all the capabilities
check in kernel or be capable of the CAP_SYS_ADMIN capability.

Check the CAP_SYS_ADMIN capability of the process which executes the
GAS access MRPC commands.

Signed-off-by: Kelvin Cao <kelvin.cao@microchip.com>