### PR TITLE
Fixed misaligned MMIO data member for ARM64 support

### DIFF
--- a/linux/switchtec.h
+++ b/linux/switchtec.h
@@ -301,7 +301,8 @@ struct ntb_info_regs {
 	u8  partition_count;
 	u8  partition_id;
 	u16 reserved1;
-	u64 ep_map;
+	u32 ep_map_low;
+	u32 ep_map_high;
 	u16 requester_id;
 	u16 reserved2;
 	u32 reserved3[4];

--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -904,7 +904,9 @@ static int switchtec_ntb_init_sndev(struct switchtec_ntb *sndev)
 	tpart_vec <<= 32;
 	tpart_vec |= ioread32(&sndev->mmio_ntb->ntp_info[self].target_part_low);
 
-	part_map = ioread64(&sndev->mmio_ntb->ep_map);
+	part_map = ioread32(&sndev->mmio_ntb->ep_map_high);
+	part_map <<= 32;
+	part_map |= ioread32(&sndev->mmio_ntb->ep_map_low);
 	tpart_vec &= part_map;
 	part_map &= ~(1 << sndev->self_partition);
 


### PR DESCRIPTION
The switchtec drivers uses packed structs for MMIO addressing to the PCIe
switch BARs. Within the packed struct ntb_info_regs the u64 member ep_map
was found to be misaligned. The misalignment was discovered on an ARM64
processor through a kernel panic traced to a Load Register operation when
addressing the misaligned member. The misaligned member is currently only
being used by the ntb_hw_switchtec driver.

Dividing the misaligned u64 member into two u32 members resolves the
misalignment. Minor bitwise operations in ntb_hw_switchtec driver were
added to recover u64 value. Adding this fix will allow the ntb_hw_switchtec
driver to support the ARM64 architecture.

Signed-off-by: Paul Selles <paul.selles@microchip.com>