### PR TITLE
Read out error code when FW return STATUS_ERROR for MRPC command

### DIFF
--- a/switchtec.c
+++ b/switchtec.c
@@ -208,13 +208,14 @@ static void mrpc_complete_cmd(struct switchtec_dev *stdev)
 	stuser_set_state(stuser, MRPC_DONE);
 	stuser->return_code = 0;
 
-	if (stuser->status != SWITCHTEC_MRPC_STATUS_DONE)
-		goto out;
-
 	if (stdev->dma_mrpc)
 		stuser->return_code = stdev->dma_mrpc->rtn_code;
 	else
 		stuser->return_code = ioread32(&stdev->mmio_mrpc->ret_value);
+
+	if (stuser->status != SWITCHTEC_MRPC_STATUS_DONE)
+		goto out;
+
 	if (stuser->return_code != 0)
 		goto out;
 
@@ -572,6 +573,8 @@ out:
 		return size;
 	else if (stuser->status == SWITCHTEC_MRPC_STATUS_INTERRUPTED)
 		return -ENXIO;
+	else if (stuser->status == SWITCHTEC_MRPC_STATUS_ERROR)
+		return -EIO;
 	else
 		return -EBADMSG;
 }


### PR DESCRIPTION
If an error is encountered when executing the MRPC command, firmware will set SWITCHTEC_MRPC_STATUS_ERROR and return the error code in return value register. We return this error code along with error number -ECOMM.

This fix does the same as in switchtec_user PR#190, except in PR190, the fix applies to I2C and UART devices, while this fix is for In-Band device. 

Note the new ECOMM error number, later switchtec-user will add check for this error code and read out the error number as well. -- See switchtec-user PR#191