### PR TITLE
Fix an error status handling issue of MRPC

### DIFF
--- a/switchtec.c
+++ b/switchtec.c
@@ -208,7 +208,8 @@ static void mrpc_complete_cmd(struct switchtec_dev *stdev)
 	stuser_set_state(stuser, MRPC_DONE);
 	stuser->return_code = 0;
 
-	if (stuser->status != SWITCHTEC_MRPC_STATUS_DONE)
+	if (stuser->status != SWITCHTEC_MRPC_STATUS_DONE &&
+	    stuser->status != SWITCHTEC_MRPC_STATUS_ERROR)
 		goto out;
 
 	if (stdev->dma_mrpc)
@@ -568,7 +569,8 @@ static ssize_t switchtec_dev_read(struct file *filp, char __user *data,
 out:
 	mutex_unlock(&stdev->mrpc_mutex);
 
-	if (stuser->status == SWITCHTEC_MRPC_STATUS_DONE)
+	if (stuser->status == SWITCHTEC_MRPC_STATUS_DONE ||
+	    stuser->status == SWITCHTEC_MRPC_STATUS_ERROR)
 		return size;
 	else if (stuser->status == SWITCHTEC_MRPC_STATUS_INTERRUPTED)
 		return -ENXIO;


### PR DESCRIPTION
If an error is encountered when executing the MRPC command, firmware
will set status register to SWITCHTEC_MRPC_STATUS_ERROR and return
the specific error code in return value register. Fix driver to
align with this behavior.

Generally, we should treat the SWITCHTEC_MRPC_STATUS_ERROR as kind of complete of the MRPC, rather than a failure, as we still need to check the return code with this status.