### PR TITLE
Req id review

### DIFF
--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -1000,7 +1000,7 @@ static int config_req_id_table(struct switchtec_ntb *sndev,
 	u32 error;
 	u32 proxy_id;
 
-	if (ioread32(&mmio_ctrl->req_id_table_size) < count) {
+	if (ioread16(&mmio_ctrl->req_id_table_size) < count) {
 		dev_err(&sndev->stdev->dev,
 			"Not enough requester IDs available.\n");
 		return -EFAULT;


### PR DESCRIPTION
In current NTB driver, we add requester IDs for RC and USP dynamically during driver initialization. This overrides the requester IDs pre-configured from config file. 

This PR adds NTB driver the capability of awareness of pre-configured requester IDs and avoid overriding them when adding new ones. And, a sysfs file ntb/requester_ids is introduced for adding, deleting and showing requester IDs dynamically at run time. 

Besides the feature changes, a minor bug in config_req_id_table()  is also fixed.


