### PR TITLE
Update the way of getting vep instance id

### DIFF
--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -460,7 +460,8 @@ static void switchtec_ntb_part_link_speed(struct switchtec_ntb *sndev,
 	u32 linksta;
 
 	pff = ioread32(&stdev->mmio_part_cfg_all[partition].vep_pff_inst_id);
-	if (pff == 0xFFFFFFFF) {
+	pff &= 0xFF;
+	if (pff == 0xFF) {
 		dev_warn(&sndev->stdev->dev,
 			 "Invalid pff, setting speed/width to 0");
 		*speed = 0;
@@ -1255,7 +1256,7 @@ static int crosslink_enum_partition(struct switchtec_ntb *sndev,
 {
 	struct part_cfg_regs __iomem *part_cfg =
 		&sndev->stdev->mmio_part_cfg_all[sndev->peer_partition];
-	u32 pff = ioread32(&part_cfg->vep_pff_inst_id);
+	u32 pff = ioread32(&part_cfg->vep_pff_inst_id) & 0xFF;
 	struct pff_csr_regs __iomem *mmio_pff =
 		&sndev->stdev->mmio_pff_csr[pff];
 	const u64 bar_space = 0x1000000000LL;

--- a/switchtec.c
+++ b/switchtec.c
@@ -1081,7 +1081,7 @@ static int ioctl_pff_to_port(struct switchtec_dev *stdev,
 			break;
 		}
 
-		reg = ioread32(&pcfg->vep_pff_inst_id);
+		reg = ioread32(&pcfg->vep_pff_inst_id) & 0xFF;
 		if (reg == p.pff) {
 			p.port = SWITCHTEC_IOCTL_PFF_VEP;
 			break;
@@ -1127,7 +1127,7 @@ static int ioctl_port_to_pff(struct switchtec_dev *stdev,
 		p.pff = ioread32(&pcfg->usp_pff_inst_id);
 		break;
 	case SWITCHTEC_IOCTL_PFF_VEP:
-		p.pff = ioread32(&pcfg->vep_pff_inst_id);
+		p.pff = ioread32(&pcfg->vep_pff_inst_id) & 0xFF;
 		break;
 	default:
 		if (p.port > ARRAY_SIZE(pcfg->dsp_pff_inst_id))
@@ -1499,7 +1499,7 @@ static void init_pff(struct switchtec_dev *stdev)
 	if (reg < stdev->pff_csr_count)
 		stdev->pff_local[reg] = 1;
 
-	reg = ioread32(&pcfg->vep_pff_inst_id);
+	reg = ioread32(&pcfg->vep_pff_inst_id) & 0xFF;
 	if (reg < stdev->pff_csr_count)
 		stdev->pff_local[reg] = 1;
 


### PR DESCRIPTION
per firmware change. Firmware updated the GAS field VEP_PFF_INST_ID
in partition region to add DMA EP and NVMe EP support. Update the
drivers accordingly.