### PR TITLE
Remove code for disabling ID protection

### DIFF
--- a/linux/switchtec.h
+++ b/linux/switchtec.h
@@ -358,8 +358,6 @@ enum {
 	NTB_CTRL_REQ_ID_EN = 1 << 0,
 
 	NTB_CTRL_LUT_EN = 1 << 0,
-
-	NTB_PART_CTRL_ID_PROT_DIS = 1 << 0,
 };
 
 struct ntb_ctrl_regs {

--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -1021,8 +1021,6 @@ static int add_req_id(struct switchtec_ntb *sndev,
 	if (rc)
 		return rc;
 
-	iowrite32(NTB_PART_CTRL_ID_PROT_DIS, &mmio_ctrl->partition_ctrl);
-
 	for (i = 0; i < table_size; i++) {
 		proxy_id = ioread32(&mmio_ctrl->req_id_table[i]);
 
@@ -1087,8 +1085,6 @@ static int del_req_id(struct switchtec_ntb *sndev,
 	if (rc)
 		return rc;
 
-	iowrite32(NTB_PART_CTRL_ID_PROT_DIS, &mmio_ctrl->partition_ctrl);
-
 	for (i = 0; i < table_size; i++) {
 		rid = ioread32(&mmio_ctrl->req_id_table[i]);
 
@@ -1141,9 +1137,6 @@ static int clr_req_ids(struct switchtec_ntb *sndev,
 				   NTB_CTRL_PART_STATUS_LOCKED);
 	if (rc)
 		return rc;
-
-	iowrite32(NTB_PART_CTRL_ID_PROT_DIS,
-		  &mmio_ctrl->partition_ctrl);
 
 	for (i = 0; i < table_size; i++)
 		iowrite32(0, &mmio_ctrl->req_id_table[i]);


### PR DESCRIPTION
ID protection is a static setting in the Switchtec config file. We
shouldn't disable it in the driver, otherwise the setting in the config
file will not take effect.