### PR TITLE
Nt improve

### DIFF
--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -1853,6 +1853,8 @@ static void switchtec_ntb_remove(struct device *dev,
 	if (!sndev)
 		return;
 
+	flush_scheduled_work();
+
 	stdev->link_notifier = NULL;
 	stdev->sndev = NULL;
 	sysfs_remove_group(&sndev->ntb.dev.kobj, &switchtec_ntb_device_group);

--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -134,9 +134,9 @@ static struct switchtec_ntb *ntb_sndev(struct ntb_dev *ntb)
 	return container_of(ntb, struct switchtec_ntb, ntb);
 }
 
-static int switchtec_ntb_part_op(struct switchtec_ntb *sndev,
-				 struct ntb_ctrl_regs __iomem *ctl,
-				 u32 op, int wait_status)
+static int switchtec_ntb_part_op_no_retry(struct switchtec_ntb *sndev,
+					  struct ntb_ctrl_regs __iomem *ctl,
+					  u32 op, int wait_status)
 {
 	static const char * const op_text[] = {
 		[NTB_CTRL_PART_OP_LOCK] = "lock",
@@ -147,6 +147,24 @@ static int switchtec_ntb_part_op(struct switchtec_ntb *sndev,
 	int i;
 	u32 ps;
 	int status;
+	int part_id, locked_part_id;
+	int xlink_peer = ctl == sndev->mmio_xlink_peer_ctrl ? 1 : 0;
+
+	ps = ioread32(&ctl->partition_status);
+
+	locked_part_id = (ps & 0xFF0000) >> 16;
+	part_id = (ps & 0xFF000000) >> 24;
+
+	ps &= 0xFFFF;
+
+	if (ps != NTB_CTRL_PART_STATUS_NORMAL &&
+	    ps != NTB_CTRL_PART_STATUS_LOCKED)
+		return -EAGAIN;
+
+	if (ps == NTB_CTRL_PART_STATUS_LOCKED)
+		if ((xlink_peer && (locked_part_id != part_id)) ||
+		    (!xlink_peer && (locked_part_id != sndev->self_partition)))
+			return -EAGAIN;
 
 	switch (op) {
 	case NTB_CTRL_PART_OP_LOCK:
@@ -170,10 +188,22 @@ static int switchtec_ntb_part_op(struct switchtec_ntb *sndev,
 			return -EINTR;
 		}
 
-		ps = ioread32(&ctl->partition_status) & 0xFFFF;
+		ps = ioread32(&ctl->partition_status);
+
+		locked_part_id = (ps & 0xFF0000) >> 16;
+		part_id = (ps & 0xFF000000) >> 24;
+
+		ps &= 0xFFFF;
 
 		if (ps != status)
 			break;
+	}
+
+	if (ps == NTB_CTRL_PART_STATUS_LOCKED) {
+		if ((xlink_peer && (locked_part_id != part_id)) ||
+		    (!xlink_peer &&
+		     (locked_part_id != sndev->self_partition)))
+			return -EAGAIN;
 	}
 
 	if (ps == wait_status)
@@ -189,6 +219,28 @@ static int switchtec_ntb_part_op(struct switchtec_ntb *sndev,
 	}
 
 	return -EIO;
+}
+
+static int switchtec_ntb_part_op(struct switchtec_ntb *sndev,
+				 struct ntb_ctrl_regs __iomem *ctl,
+				 u32 op, int wait_status)
+{
+	int rc;
+	int i = 0;
+
+	while (i++ < 10) {
+		rc = switchtec_ntb_part_op_no_retry(sndev, ctl, op,
+						    wait_status);
+		if (rc == -EAGAIN) {
+			if (msleep_interruptible(30) != 0)
+				return -EINTR;
+			continue;
+		}
+
+		break;
+	}
+
+	return rc;
 }
 
 static int switchtec_ntb_send_msg(struct switchtec_ntb *sndev, int idx,

--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -1417,10 +1417,6 @@ static int switchtec_ntb_init_crosslink(struct switchtec_ntb *sndev)
 	if (rc)
 		return rc;
 
-	crosslink_init_dbmsgs(sndev);
-
-	crosslink_setup_req_ids(sndev, sndev->mmio_xlink_peer_ctrl);
-
 	return 0;
 }
 

--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -688,8 +688,6 @@ static int switchtec_ntb_link_enable(struct ntb_dev *ntb,
 	sndev->self_shared->link_sta = 1;
 	switchtec_ntb_send_msg(sndev, LINK_MESSAGE, MSG_LINK_UP);
 
-	switchtec_ntb_link_status_update(sndev);
-
 	return 0;
 }
 


### PR DESCRIPTION
In commit fd0edeee119ee3684d1e2e111cb6fe09a636dbb9, we corrected the requester ID registration for crosslink setup. However, this fix introduced a new competition condition we didn't take good care of. When adding a requester ID to the crosslink peer partition, it will require the NT partition state transition to take place on that partitoin. In the meantime, the peer host may be doing some other setup like creating a new LUT window which requires the state transition to take place on the same partition. 

This PR improved the code by
- Fix a minor issue in the driver removal
- Add code to check for the competition condition with retries for crosslink.
- Improve the link up/status update protocol for crosslink.