### PR TITLE
Fix a doorbell issue in the crosslink mode

### DIFF
--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -863,6 +863,8 @@ static int switchtec_ntb_link_enable(struct ntb_dev *ntb,
 	dev_dbg(&sndev->stdev->dev, "enabling link\n");
 
 	sndev->self_shared->link_sta = 1;
+	switchtec_ntb_link_status_update(sndev);
+
 	switchtec_ntb_send_msg(sndev, LINK_MESSAGE, MSG_LINK_UP);
 
 	return 0;

--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -598,6 +598,47 @@ static int switchtec_ntb_reinit_peer(struct switchtec_ntb *sndev);
 static int crosslink_setup_req_ids(struct switchtec_ntb *sndev,
 		struct ntb_ctrl_regs __iomem *mmio_ctrl);
 
+static int config_rsvd_lut_win(struct switchtec_ntb *sndev,
+			       struct ntb_ctrl_regs __iomem *ctl,
+			       int lut_idx, int partition, u64 addr)
+{
+	int peer_bar = sndev->peer_direct_mw_to_bar[0];
+	u32 ctl_val;
+	int rc;
+
+	mutex_lock(&sndev->nt_op_lock);
+	rc = switchtec_ntb_part_op(sndev, ctl, NTB_CTRL_PART_OP_LOCK,
+				   NTB_CTRL_PART_STATUS_LOCKED);
+	if (rc)
+		goto unlock_exit;
+
+	ctl_val = ioread32(&ctl->bar_entry[peer_bar].ctl);
+	ctl_val &= 0xFF;
+	ctl_val |= NTB_CTRL_BAR_LUT_WIN_EN;
+	ctl_val |= ilog2(LUT_SIZE) << 8;
+	ctl_val |= (sndev->nr_lut_mw - 1) << 14;
+	iowrite32(ctl_val, &ctl->bar_entry[peer_bar].ctl);
+
+	iowrite64((NTB_CTRL_LUT_EN | (partition << 1) | addr),
+		  &ctl->lut_entry[lut_idx]);
+
+	rc = switchtec_ntb_part_op(sndev, ctl, NTB_CTRL_PART_OP_CFG,
+				   NTB_CTRL_PART_STATUS_NORMAL);
+	if (rc) {
+		u32 bar_error, lut_error;
+
+		bar_error = ioread32(&ctl->bar_error);
+		lut_error = ioread32(&ctl->lut_error);
+		dev_err(&sndev->stdev->dev,
+			"Error setting up reserved lut window: %08x / %08x\n",
+			bar_error, lut_error);
+	}
+
+unlock_exit:
+	mutex_unlock(&sndev->nt_op_lock);
+	return rc;
+}
+
 static void switchtec_ntb_link_status_update(struct switchtec_ntb *sndev)
 {
 	int link_sta;
@@ -1022,47 +1063,6 @@ static int switchtec_ntb_init_sndev(struct switchtec_ntb *sndev)
 	mutex_init(&sndev->nt_op_lock);
 
 	return 0;
-}
-
-static int config_rsvd_lut_win(struct switchtec_ntb *sndev,
-			       struct ntb_ctrl_regs __iomem *ctl,
-			       int lut_idx, int partition, u64 addr)
-{
-	int peer_bar = sndev->peer_direct_mw_to_bar[0];
-	u32 ctl_val;
-	int rc;
-
-	mutex_lock(&sndev->nt_op_lock);
-	rc = switchtec_ntb_part_op(sndev, ctl, NTB_CTRL_PART_OP_LOCK,
-				   NTB_CTRL_PART_STATUS_LOCKED);
-	if (rc)
-		goto unlock_exit;
-
-	ctl_val = ioread32(&ctl->bar_entry[peer_bar].ctl);
-	ctl_val &= 0xFF;
-	ctl_val |= NTB_CTRL_BAR_LUT_WIN_EN;
-	ctl_val |= ilog2(LUT_SIZE) << 8;
-	ctl_val |= (sndev->nr_lut_mw - 1) << 14;
-	iowrite32(ctl_val, &ctl->bar_entry[peer_bar].ctl);
-
-	iowrite64((NTB_CTRL_LUT_EN | (partition << 1) | addr),
-		  &ctl->lut_entry[lut_idx]);
-
-	rc = switchtec_ntb_part_op(sndev, ctl, NTB_CTRL_PART_OP_CFG,
-				   NTB_CTRL_PART_STATUS_NORMAL);
-	if (rc) {
-		u32 bar_error, lut_error;
-
-		bar_error = ioread32(&ctl->bar_error);
-		lut_error = ioread32(&ctl->lut_error);
-		dev_err(&sndev->stdev->dev,
-			"Error setting up reserved lut window: %08x / %08x\n",
-			bar_error, lut_error);
-	}
-
-unlock_exit:
-	mutex_unlock(&sndev->nt_op_lock);
-	return rc;
 }
 
 static int add_req_id(struct switchtec_ntb *sndev,

--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -756,6 +756,22 @@ static int switchtec_ntb_setup_crosslink(struct switchtec_ntb *sndev)
 	return 0;
 }
 
+static void switchtec_ntb_cleanup_crosslink(struct switchtec_ntb *sndev)
+{
+	if (!crosslink_is_enabled(sndev))
+		return;
+
+	if (sndev->mmio_xlink_dbmsg_win) {
+		pci_iounmap(sndev->stdev->pdev, sndev->mmio_xlink_dbmsg_win);
+		sndev->mmio_xlink_dbmsg_win = NULL;
+	}
+
+	if (sndev->mmio_xlink_ctrl_win) {
+		pci_iounmap(sndev->stdev->pdev, sndev->mmio_xlink_ctrl_win);
+		sndev->mmio_xlink_ctrl_win = NULL;
+	}
+}
+
 static void switchtec_ntb_link_status_update(struct switchtec_ntb *sndev)
 {
 	int link_sta;
@@ -796,6 +812,7 @@ static void check_link_status_work(struct work_struct *work)
 	if (sndev->link_force_down) {
 		sndev->link_force_down = false;
 		switchtec_ntb_reinit_peer(sndev);
+		switchtec_ntb_cleanup_crosslink(sndev);
 
 		if (sndev->link_is_up) {
 			sndev->link_is_up = 0;
@@ -1530,14 +1547,10 @@ static int switchtec_ntb_init_crosslink(struct switchtec_ntb *sndev)
 
 static void switchtec_ntb_deinit_crosslink(struct switchtec_ntb *sndev)
 {
-	if (sndev->mmio_xlink_dbmsg_win)
-		pci_iounmap(sndev->stdev->pdev, sndev->mmio_xlink_dbmsg_win);
-
-	if (sndev->mmio_xlink_ctrl_win)
-		pci_iounmap(sndev->stdev->pdev, sndev->mmio_xlink_ctrl_win);
-
 	if (sndev->mmio_xlink_ntinfo_win)
 		pci_iounmap(sndev->stdev->pdev, sndev->mmio_xlink_ntinfo_win);
+
+	switchtec_ntb_cleanup_crosslink(sndev);
 }
 
 static int map_bars(int *map, struct ntb_ctrl_regs __iomem *ctrl)

--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -711,6 +711,12 @@ static int switchtec_ntb_setup_crosslink(struct switchtec_ntb *sndev)
 		sndev->nr_rsvd_luts++;
 	}
 
+	crosslink_init_dbmsgs(sndev);
+
+	rc = crosslink_setup_req_ids(sndev, sndev->mmio_xlink_peer_ctrl);
+	if (rc)
+		return rc;
+
 	return 0;
 }
 
@@ -722,10 +728,8 @@ static void switchtec_ntb_link_status_update(struct switchtec_ntb *sndev)
 
 	link_sta = sndev->self_shared->link_sta;
 	if (link_sta) {
-		if (!sndev->link_is_up && crosslink_is_enabled(sndev)) {
-			crosslink_setup_req_ids(sndev, sndev->mmio_xlink_peer_ctrl);
+		if (!sndev->link_is_up && crosslink_is_enabled(sndev))
 			switchtec_ntb_setup_crosslink(sndev);
-		}
 
 		peer = ioread64(&sndev->peer_shared->magic);
 
@@ -743,9 +747,6 @@ static void switchtec_ntb_link_status_update(struct switchtec_ntb *sndev)
 		ntb_link_event(&sndev->ntb);
 		dev_info(&sndev->stdev->dev, "ntb link %s\n",
 			 link_sta ? "up" : "down");
-
-		if (link_sta)
-			crosslink_init_dbmsgs(sndev);
 	}
 }
 

--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -720,7 +720,6 @@ static int switchtec_ntb_setup_crosslink(struct switchtec_ntb *sndev)
 
 		sndev->mmio_xlink_peer_ctrl = sndev->mmio_xlink_ctrl_win +
 			offset;
-		sndev->nr_rsvd_luts++;
 	}
 
 	if (!sndev->mmio_xlink_dbmsg_win) {
@@ -744,7 +743,6 @@ static int switchtec_ntb_setup_crosslink(struct switchtec_ntb *sndev)
 			return -ENOMEM;
 
 		sndev->mmio_peer_dbmsg = sndev->mmio_xlink_dbmsg_win + offset;
-		sndev->nr_rsvd_luts++;
 	}
 
 	crosslink_init_dbmsgs(sndev);
@@ -1515,6 +1513,7 @@ static int switchtec_ntb_init_crosslink(struct switchtec_ntb *sndev)
 		return -EINVAL;
 	}
 
+	sndev->nr_rsvd_luts += 3;
 	rc = crosslink_setup_mws(sndev, NT_INFO_LUT, DB_MSG_LUT, REQ_ID_LUT,
 				 &bar_addrs[1], bar_cnt - 1);
 	if (rc)
@@ -1540,7 +1539,6 @@ static int switchtec_ntb_init_crosslink(struct switchtec_ntb *sndev)
 	}
 
 	sndev->mmio_xlink_peer_ntb = sndev->mmio_xlink_ntinfo_win + offset;
-	sndev->nr_rsvd_luts++;
 
 	return 0;
 }

--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -1556,7 +1556,7 @@ static void switchtec_ntb_init_db(struct switchtec_ntb *sndev)
 {
 	sndev->db_mask = 0x0FFFFFFFFFFFFFFFULL;
 
-	if (sndev->mmio_peer_dbmsg != sndev->mmio_self_dbmsg) {
+	if (crosslink_is_enabled(sndev)) {
 		sndev->db_shift = 0;
 		sndev->db_peer_shift = 0;
 		sndev->db_valid_mask = sndev->db_mask;

--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -647,6 +647,73 @@ enum {
 
 static u64 bar_addrs[6];
 
+static int switchtec_ntb_setup_crosslink(struct switchtec_ntb *sndev)
+{
+	int rc;
+	int bar = sndev->direct_mw_to_bar[0];
+	u64 addr;
+	int offset;
+	int xlink_peer;
+
+	if (!crosslink_is_enabled(sndev))
+		return 0;
+
+	xlink_peer = ioread8(&sndev->mmio_xlink_peer_ntb->partition_id);
+	if (xlink_peer == 0xFF)
+		return -EIO;
+
+	if (!sndev->mmio_xlink_ctrl_win) {
+		addr = (bar_addrs[0] + SWITCHTEC_GAS_NTB_OFFSET +
+			SWITCHTEC_NTB_REG_CTRL_OFFSET +
+			sizeof(struct ntb_ctrl_regs) * xlink_peer);
+
+		offset = addr & (LUT_SIZE - 1);
+		addr -= offset;
+
+		rc = config_rsvd_lut_win(sndev, sndev->mmio_self_ctrl,
+					 REQ_ID_LUT, sndev->peer_partition,
+					 addr);
+		if (rc)
+			return rc;
+
+		sndev->mmio_xlink_ctrl_win =
+			pci_iomap_range(sndev->stdev->pdev, bar,
+					REQ_ID_LUT * LUT_SIZE, LUT_SIZE);
+		if (!sndev->mmio_xlink_ctrl_win)
+			return -ENOMEM;
+
+		sndev->mmio_xlink_peer_ctrl = sndev->mmio_xlink_ctrl_win +
+			offset;
+		sndev->nr_rsvd_luts++;
+	}
+
+	if (!sndev->mmio_xlink_dbmsg_win) {
+		addr = (bar_addrs[0] + SWITCHTEC_GAS_NTB_OFFSET +
+			SWITCHTEC_NTB_REG_DBMSG_OFFSET +
+			sizeof(struct ntb_dbmsg_regs) * xlink_peer);
+
+		offset = addr & (LUT_SIZE - 1);
+		addr -= offset;
+
+		rc = config_rsvd_lut_win(sndev, sndev->mmio_self_ctrl,
+					 DB_MSG_LUT, sndev->peer_partition,
+					 addr);
+		if (rc)
+			return rc;
+
+		sndev->mmio_xlink_dbmsg_win =
+			pci_iomap_range(sndev->stdev->pdev, bar,
+					DB_MSG_LUT * LUT_SIZE, LUT_SIZE);
+		if (!sndev->mmio_xlink_dbmsg_win)
+			return -ENOMEM;
+
+		sndev->mmio_peer_dbmsg = sndev->mmio_xlink_dbmsg_win + offset;
+		sndev->nr_rsvd_luts++;
+	}
+
+	return 0;
+}
+
 static void switchtec_ntb_link_status_update(struct switchtec_ntb *sndev)
 {
 	int link_sta;
@@ -655,8 +722,10 @@ static void switchtec_ntb_link_status_update(struct switchtec_ntb *sndev)
 
 	link_sta = sndev->self_shared->link_sta;
 	if (link_sta) {
-		if (!sndev->link_is_up && crosslink_is_enabled(sndev))
+		if (!sndev->link_is_up && crosslink_is_enabled(sndev)) {
 			crosslink_setup_req_ids(sndev, sndev->mmio_xlink_peer_ctrl);
+			switchtec_ntb_setup_crosslink(sndev);
+		}
 
 		peer = ioread64(&sndev->peer_shared->magic);
 
@@ -1391,53 +1460,6 @@ static int switchtec_ntb_init_crosslink(struct switchtec_ntb *sndev)
 			"Error enumerating crosslink partition\n");
 		return -EINVAL;
 	}
-
-	addr = (bar_addrs[0] + SWITCHTEC_GAS_NTB_OFFSET +
-		SWITCHTEC_NTB_REG_DBMSG_OFFSET +
-		sizeof(struct ntb_dbmsg_regs) * sndev->peer_partition);
-
-	offset = addr & (LUT_SIZE - 1);
-	addr -= offset;
-
-	rc = config_rsvd_lut_win(sndev, sndev->mmio_self_ctrl, DB_MSG_LUT,
-				 sndev->peer_partition, addr);
-	if (rc)
-		return rc;
-
-	sndev->mmio_xlink_dbmsg_win = pci_iomap_range(sndev->stdev->pdev, bar,
-						      DB_MSG_LUT * LUT_SIZE,
-						      LUT_SIZE);
-	if (!sndev->mmio_xlink_dbmsg_win) {
-		rc = -ENOMEM;
-		return rc;
-	}
-
-	sndev->mmio_peer_dbmsg = sndev->mmio_xlink_dbmsg_win + offset;
-	sndev->nr_rsvd_luts++;
-
-	addr = (bar_addrs[0] + SWITCHTEC_GAS_NTB_OFFSET +
-		SWITCHTEC_NTB_REG_CTRL_OFFSET +
-		sizeof(struct ntb_ctrl_regs) * sndev->peer_partition);
-
-	offset = addr & (LUT_SIZE - 1);
-	addr -= offset;
-
-	rc = config_rsvd_lut_win(sndev, sndev->mmio_self_ctrl,
-				 REQ_ID_LUT,
-				 sndev->peer_partition, addr);
-	if (rc)
-		return rc;
-
-	sndev->mmio_xlink_ctrl_win = pci_iomap_range(sndev->stdev->pdev, bar,
-						     REQ_ID_LUT * LUT_SIZE,
-						     LUT_SIZE);
-	if (!sndev->mmio_xlink_ctrl_win) {
-		rc = -ENOMEM;
-		return rc;
-	}
-
-	sndev->mmio_xlink_peer_ctrl = sndev->mmio_xlink_ctrl_win + offset;
-	sndev->nr_rsvd_luts++;
 
 	rc = crosslink_setup_mws(sndev, NT_INFO_LUT, DB_MSG_LUT, REQ_ID_LUT,
 				 &bar_addrs[1], bar_cnt - 1);

--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -639,6 +639,14 @@ unlock_exit:
 	return rc;
 }
 
+enum {
+	NT_INFO_LUT = 1,
+	DB_MSG_LUT = 2,
+	REQ_ID_LUT = 3,
+};
+
+static u64 bar_addrs[6];
+
 static void switchtec_ntb_link_status_update(struct switchtec_ntb *sndev)
 {
 	int link_sta;
@@ -1367,10 +1375,6 @@ static int switchtec_ntb_init_crosslink(struct switchtec_ntb *sndev)
 {
 	int rc;
 	int bar = sndev->direct_mw_to_bar[0];
-	const int ntinfo_lut_idx = 1;
-	const int dbmsg_lut_idx = 2;
-	const int req_id_lut_idx = 3;
-	u64 bar_addrs[6];
 	u64 addr;
 	int offset;
 	int bar_cnt;
@@ -1395,13 +1399,13 @@ static int switchtec_ntb_init_crosslink(struct switchtec_ntb *sndev)
 	offset = addr & (LUT_SIZE - 1);
 	addr -= offset;
 
-	rc = config_rsvd_lut_win(sndev, sndev->mmio_self_ctrl, dbmsg_lut_idx,
+	rc = config_rsvd_lut_win(sndev, sndev->mmio_self_ctrl, DB_MSG_LUT,
 				 sndev->peer_partition, addr);
 	if (rc)
 		return rc;
 
 	sndev->mmio_xlink_dbmsg_win = pci_iomap_range(sndev->stdev->pdev, bar,
-						      dbmsg_lut_idx * LUT_SIZE,
+						      DB_MSG_LUT * LUT_SIZE,
 						      LUT_SIZE);
 	if (!sndev->mmio_xlink_dbmsg_win) {
 		rc = -ENOMEM;
@@ -1419,13 +1423,13 @@ static int switchtec_ntb_init_crosslink(struct switchtec_ntb *sndev)
 	addr -= offset;
 
 	rc = config_rsvd_lut_win(sndev, sndev->mmio_self_ctrl,
-				 req_id_lut_idx,
+				 REQ_ID_LUT,
 				 sndev->peer_partition, addr);
 	if (rc)
 		return rc;
 
 	sndev->mmio_xlink_ctrl_win = pci_iomap_range(sndev->stdev->pdev, bar,
-						     req_id_lut_idx * LUT_SIZE,
+						     REQ_ID_LUT * LUT_SIZE,
 						     LUT_SIZE);
 	if (!sndev->mmio_xlink_ctrl_win) {
 		rc = -ENOMEM;
@@ -1435,8 +1439,8 @@ static int switchtec_ntb_init_crosslink(struct switchtec_ntb *sndev)
 	sndev->mmio_xlink_peer_ctrl = sndev->mmio_xlink_ctrl_win + offset;
 	sndev->nr_rsvd_luts++;
 
-	rc = crosslink_setup_mws(sndev, ntinfo_lut_idx, dbmsg_lut_idx,
-				 req_id_lut_idx, &bar_addrs[1], bar_cnt - 1);
+	rc = crosslink_setup_mws(sndev, NT_INFO_LUT, DB_MSG_LUT, REQ_ID_LUT,
+				 &bar_addrs[1], bar_cnt - 1);
 	if (rc)
 		return rc;
 
@@ -1446,14 +1450,14 @@ static int switchtec_ntb_init_crosslink(struct switchtec_ntb *sndev)
 	offset = addr & (LUT_SIZE - 1);
 	addr -= offset;
 
-	rc = config_rsvd_lut_win(sndev, sndev->mmio_self_ctrl, ntinfo_lut_idx,
+	rc = config_rsvd_lut_win(sndev, sndev->mmio_self_ctrl, NT_INFO_LUT,
 				 sndev->peer_partition, addr);
 	if (rc)
 		return rc;
 
 	sndev->mmio_xlink_ntinfo_win = pci_iomap_range(sndev->stdev->pdev, bar,
-						       ntinfo_lut_idx *
-						       LUT_SIZE, LUT_SIZE);
+						       NT_INFO_LUT * LUT_SIZE,
+						       LUT_SIZE);
 	if (!sndev->mmio_xlink_ntinfo_win) {
 		rc = -ENOMEM;
 		return rc;

--- a/ntb_hw_switchtec.c
+++ b/ntb_hw_switchtec.c
@@ -90,6 +90,7 @@ struct switchtec_ntb {
 	int message_irq;
 
 	struct ntb_info_regs __iomem *mmio_ntb;
+	struct ntb_info_regs __iomem *mmio_xlink_peer_ntb;
 	struct ntb_ctrl_regs __iomem *mmio_ctrl;
 	struct ntb_dbmsg_regs __iomem *mmio_dbmsg;
 	struct ntb_ctrl_regs __iomem *mmio_self_ctrl;
@@ -98,6 +99,7 @@ struct switchtec_ntb {
 	struct ntb_dbmsg_regs __iomem *mmio_self_dbmsg;
 	struct ntb_dbmsg_regs __iomem *mmio_peer_dbmsg;
 
+	void __iomem *mmio_xlink_ntinfo_win;
 	void __iomem *mmio_xlink_dbmsg_win;
 	void __iomem *mmio_xlink_ctrl_win;
 
@@ -1225,6 +1227,7 @@ unlock_exit:
 }
 
 static int crosslink_setup_mws(struct switchtec_ntb *sndev,
+			       int ntb_ntinfo_lut_idx,
 			       int ntb_dbmsg_lut_idx,
 			       int ntb_req_id_lut_idx,
 			       u64 *mw_addrs, int mw_count)
@@ -1244,7 +1247,8 @@ static int crosslink_setup_mws(struct switchtec_ntb *sndev,
 		goto unlock_exit;
 
 	for (i = 0; i < sndev->nr_lut_mw; i++) {
-		if (i == ntb_dbmsg_lut_idx || i == ntb_req_id_lut_idx)
+		if (i == ntb_ntinfo_lut_idx || i == ntb_dbmsg_lut_idx ||
+		    i == ntb_req_id_lut_idx)
 			continue;
 
 		addr = mw_addrs[0] + LUT_SIZE * i;
@@ -1363,8 +1367,9 @@ static int switchtec_ntb_init_crosslink(struct switchtec_ntb *sndev)
 {
 	int rc;
 	int bar = sndev->direct_mw_to_bar[0];
-	const int dbmsg_lut_idx = 1;
-	const int req_id_lut_idx = 2;
+	const int ntinfo_lut_idx = 1;
+	const int dbmsg_lut_idx = 2;
+	const int req_id_lut_idx = 3;
 	u64 bar_addrs[6];
 	u64 addr;
 	int offset;
@@ -1430,10 +1435,32 @@ static int switchtec_ntb_init_crosslink(struct switchtec_ntb *sndev)
 	sndev->mmio_xlink_peer_ctrl = sndev->mmio_xlink_ctrl_win + offset;
 	sndev->nr_rsvd_luts++;
 
-	rc = crosslink_setup_mws(sndev, dbmsg_lut_idx, req_id_lut_idx,
-				 &bar_addrs[1], bar_cnt - 1);
+	rc = crosslink_setup_mws(sndev, ntinfo_lut_idx, dbmsg_lut_idx,
+				 req_id_lut_idx, &bar_addrs[1], bar_cnt - 1);
 	if (rc)
 		return rc;
+
+	addr = (bar_addrs[0] + SWITCHTEC_GAS_NTB_OFFSET +
+		SWITCHTEC_NTB_REG_INFO_OFFSET);
+
+	offset = addr & (LUT_SIZE - 1);
+	addr -= offset;
+
+	rc = config_rsvd_lut_win(sndev, sndev->mmio_self_ctrl, ntinfo_lut_idx,
+				 sndev->peer_partition, addr);
+	if (rc)
+		return rc;
+
+	sndev->mmio_xlink_ntinfo_win = pci_iomap_range(sndev->stdev->pdev, bar,
+						       ntinfo_lut_idx *
+						       LUT_SIZE, LUT_SIZE);
+	if (!sndev->mmio_xlink_ntinfo_win) {
+		rc = -ENOMEM;
+		return rc;
+	}
+
+	sndev->mmio_xlink_peer_ntb = sndev->mmio_xlink_ntinfo_win + offset;
+	sndev->nr_rsvd_luts++;
 
 	return 0;
 }
@@ -1445,6 +1472,9 @@ static void switchtec_ntb_deinit_crosslink(struct switchtec_ntb *sndev)
 
 	if (sndev->mmio_xlink_ctrl_win)
 		pci_iounmap(sndev->stdev->pdev, sndev->mmio_xlink_ctrl_win);
+
+	if (sndev->mmio_xlink_ntinfo_win)
+		pci_iounmap(sndev->stdev->pdev, sndev->mmio_xlink_ntinfo_win);
 }
 
 static int map_bars(int *map, struct ntb_ctrl_regs __iomem *ctrl)


### PR DESCRIPTION
It was reported by a user that the on a crosslink platform where the local/crosslink partition ID are *not* 0/1, the link couldn't be brought up. 

It turns out that the doorbell message registers MMAP on the crosslink partition were not programmed. The target partitions of messages of crosslink partition are defined in the MMAP register. Without programming, it happens to map to partition 0 which is normally the host partition ID. 

To resolve this, we need to program the MMAP register of the crosslink partition. An intuitive approach is to let the host driver on the local switch to program the MMAP register of the corsslink partition. Unluckily, the driver is prohibited from accessing this register of other partitions on the same switch. 

However, the driver is able to program the MMAP register on the other side of a crosslink. To get the partition info of the remote switch which is necessary for the programming, a new reserved LUT was added. And as some remote NT info can only be retrieved when the remote switch is ready (up and initialized by the driver), some reserved LUTs setup cannot be done during probing and are deferred to link negotiation.